### PR TITLE
Fix ANTLR 4 grammar for accepting empty elements in lexer alternative lists

### DIFF
--- a/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/Antlr4.xtext
+++ b/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/Antlr4.xtext
@@ -406,18 +406,17 @@ LexerRuleBlock
 
 LexerAltList
   :
-    alternatives+=LexerAlt ('|' alternatives+=LexerAlt | '|')*
+    alternatives+=LexerAlt ('|' alternatives+=LexerAlt)*
   ;
 
 LexerAlt
   :
-    {LexerAlt}
     body=LexerElements commands=LexerCommands?
   ;
 
 LexerElements
   :
-  	{LexerElements}
+    {LexerElements}
     elements+=LexerElement*
   ;
 


### PR DESCRIPTION
Fix the issue #57 (Related to #42).

Note that I did not test my modification because I could not compile antlr4ide.core in my environment. Sorry.
