### PR TITLE
Support for -lib option

### DIFF
--- a/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/Antlr4Generator.xtend
+++ b/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/Antlr4Generator.xtend
@@ -18,7 +18,8 @@ import com.github.jknack.antlr4ide.services.GrammarResource
  * see http://www.eclipse.org/Xtext/documentation.html#TutorialCodeGeneration
  */
 class Antlr4Generator implements IGenerator {
-
+  static val DEBUG = false
+  
   /** The tool runner. */
   @Inject
   @Property
@@ -51,6 +52,8 @@ class Antlr4Generator implements IGenerator {
    * @param fsa The Xtext file system access (not used).
    */
   override doGenerate(Resource resource, IFileSystemAccess fsa) {
+  if(DEBUG) System::out.println("Antlr4Generator doGenerate #0. optionsProvider.class >"+optionsProvider.getClass()+"<")
+  
     checkNotNull(resource)
     checkNotNull(fsa)
     checkNotNull(toolRunner)
@@ -85,6 +88,8 @@ class Antlr4Generator implements IGenerator {
    * @param options The tools options.
    */
   private def void doGenerate(IFile file, ToolOptions options) {
+  if(DEBUG) System::out.println("Antlr4Generator doGenerate #1 ")
+  
     checkNotNull(file)
     checkNotNull(options)
 

--- a/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/ToolOptions.xtend
+++ b/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/ToolOptions.xtend
@@ -27,6 +27,8 @@ class ToolOptions {
 
   public static val BUILD_ENCODING = "antlr4.encoding"
 
+  public static val BUILD_LIBDIRECTORY = "antlr4.libdirectory"  
+
   public static val VM_ARGS = "antlr4.vmArgs"
 
   @Property
@@ -148,6 +150,22 @@ class ToolOptions {
     )
   }
 
+  def resolvePath(IFile file, String inPath)
+  { // assume path is relative to project path
+    val project = file.project
+    val projectPath = project.location
+        
+    val chkPath = new Path(inPath)    
+        
+    // Check if path is absolute
+    if (chkPath.isAbsolute) 
+      return chkPath.toOSString
+    else   
+      return projectPath.append(chkPath).toOSString
+    
+  }
+
+
   def defaults() {
     var listener = "-listener"
     if (!this.listener) {
@@ -195,8 +213,8 @@ class ToolOptions {
     )
 
     // libDirectory
-    if (libDirectory != null) {
-      options.addAll("-lib", libDirectory)
+    if (libDirectory != null && !libDirectory.equals("")) {
+      options.addAll("-lib", resolvePath(file, libDirectory))
     }
 
     // package

--- a/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/ToolOptions.xtend
+++ b/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/ToolOptions.xtend
@@ -213,7 +213,7 @@ class ToolOptions {
     )
 
     // libDirectory
-    if (libDirectory != null && !libDirectory.equals("")) {
+    if (libDirectory != null && !libDirectory.trim().equals("")) {
       options.addAll("-lib", resolvePath(file, libDirectory))
     }
 

--- a/antlr4ide.tests/src/main/java/com/github/jknack/antlr4ide/generator/ToolOptionsTest.java
+++ b/antlr4ide.tests/src/main/java/com/github/jknack/antlr4ide/generator/ToolOptionsTest.java
@@ -136,13 +136,17 @@ public class ToolOptionsTest {
     IFile file = createMock(IFile.class);
     IPath filePath = Path.fromOSString("home").append("project").append("Hello.g4");
     IPath outputPath = Path.fromOSString("target").append("generated-sources").append("antlr4");
-    IPath libPath = Path.fromOSString("home").append("project").append("lib");
+//    IPath libPath = Path.fromOSString("home").append("project").append("lib");
+    IPath libPath = Path.fromOSString("lib"); // libPath is relative to project path
 
     expect(file.getProject()).andReturn(project);
     expect(file.getLocation()).andReturn(filePath);
 
     expect(project.getLocation()).andReturn(projectPath);
 
+    expect(file.getProject()).andReturn(project); // from libpath check
+    expect(project.getLocation()).andReturn(projectPath);
+    
     Object[] mocks = {file, project };
 
     replay(mocks);
@@ -152,7 +156,7 @@ public class ToolOptionsTest {
     options.setOutputDirectory(outputPath.toOSString());
     assertEquals(Lists
         .newArrayList("-o", projectPath.append(outputPath).toOSString(), "-listener",
-            "-no-visitor", "-lib", libPath.toOSString(), "-encoding", "UTF-8"),
+            "-no-visitor", "-lib", projectPath.append(libPath).toOSString(), "-encoding", "UTF-8"),
         options.command(file));
 
     verify(mocks);

--- a/antlr4ide.tests/src/main/java/com/github/jknack/antlr4ide/generator/ToolOptionsTest.java
+++ b/antlr4ide.tests/src/main/java/com/github/jknack/antlr4ide/generator/ToolOptionsTest.java
@@ -136,7 +136,6 @@ public class ToolOptionsTest {
     IFile file = createMock(IFile.class);
     IPath filePath = Path.fromOSString("home").append("project").append("Hello.g4");
     IPath outputPath = Path.fromOSString("target").append("generated-sources").append("antlr4");
-//    IPath libPath = Path.fromOSString("home").append("project").append("lib");
     IPath libPath = Path.fromOSString("lib"); // libPath is relative to project path
 
     expect(file.getProject()).andReturn(project);

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/generator/DefaultToolOptionsProvider.xtend
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/generator/DefaultToolOptionsProvider.xtend
@@ -17,6 +17,7 @@ import org.eclipse.debug.core.ILaunchManager
 import com.github.jknack.antlr4ide.generator.LaunchConstants
 
 class DefaultToolOptionsProvider implements ToolOptionsProvider {
+  static val DEBUG = false
 
   @Inject
   private EclipseOutputConfigurationProvider configurationProvider
@@ -34,6 +35,8 @@ class DefaultToolOptionsProvider implements ToolOptionsProvider {
   static val PKG_NAME = Pattern.compile("package\\s+(([a-zA_Z_][\\.\\w]*))\\s*;")
 
   override options(IFile file) {
+  if(DEBUG) System::out.println("DefaultToolOptionsProvider options #0 "+file.getClass())
+  
     val project = file.project
     val store = preferenceStore.getContextPreferenceStore(project)
     val output = configurationProvider.getOutputConfigurations(project).last
@@ -61,6 +64,7 @@ class DefaultToolOptionsProvider implements ToolOptionsProvider {
       listener = getBoolean(ToolOptions.BUILD_LISTENER, store, true)
       visitor = getBoolean(ToolOptions.BUILD_VISITOR, store, false)
       encoding = getString(ToolOptions.BUILD_ENCODING, store, "UTF-8")
+      libDirectory = getString(ToolOptions.BUILD_LIBDIRECTORY, store, "") 
       vmArgs = getString(ToolOptions.VM_ARGS, store, "")
       derived = output.setDerivedProperty
       cleanUpDerivedResources = output.cleanUpDerivedResources
@@ -74,9 +78,13 @@ class DefaultToolOptionsProvider implements ToolOptionsProvider {
    * exists, the defaults options will be used it.
    */
   private def options(IFile file, ToolOptions defaults) {
+    if(DEBUG) System::out.println("DefaultToolOptionsProvider options #1 "+file.getClass+", "+defaults.getClass())
+  
     val grammar = file.fullPath.toOSString
     val configType = launchManager.getLaunchConfigurationType(LaunchConstants.LAUNCH_ID)
     var configurations = launchManager.getLaunchConfigurations(configType)
+
+    if(DEBUG) System::out.println("  grammar>"+grammar+"< configType>"+configType+"< configurations >"+configurations+"<")
 
     val existing = configurations.filter [ launch |
       if (grammar == launch.getAttribute(LaunchConstants.GRAMMAR, "")) {
@@ -85,11 +93,16 @@ class DefaultToolOptionsProvider implements ToolOptionsProvider {
       return false
     ]
 
+    if(DEBUG) System::out.println("   existing>"+existing+"<")
+
     if (existing.size > 0) {
 
       // launch existing
       val config = existing.head
       val args = config.getAttribute(LaunchConstants.ARGUMENTS, "")
+   if(DEBUG) System::out.println("        config>"+config.getClass()+"<>"+config+"<")
+   if(DEBUG) System::out.println("        args>"+args.getClass()+"<>"+args+"<")
+      
       val options = ToolOptions.parse(args) [ message |
       ]
 

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/preferences/BuildPreferenceStoreInitializer.xtend
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/preferences/BuildPreferenceStoreInitializer.xtend
@@ -15,6 +15,7 @@ class BuildPreferenceStoreInitializer implements IPreferenceStoreInitializer {
     store.setDefault(BUILD_LISTENER, true)
     store.setDefault(BUILD_VISITOR, false)
     store.setDefault(BUILD_ENCODING, "UTF-8")
+    store.setDefault(BUILD_LIBDIRECTORY,"")
   }
 
 }

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/preferences/BuilderConfigurationBlock.xtend
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/preferences/BuilderConfigurationBlock.xtend
@@ -111,10 +111,12 @@ class BuilderConfigurationBlock extends OptionsConfigurationBlock {
     excomposite.setClient(othersComposite)
     othersComposite.setLayout(new GridLayout(columns, false))
 
-    addTextField(othersComposite, "Directory",
+    addTextField(othersComposite, "Directory (-o)",
       BuilderPreferenceAccess.getKey(outputConfiguration,
         EclipseOutputConfigurationProvider.OUTPUT_DIRECTORY), 0, 300)
-
+        
+    addTextField(othersComposite, "Library (-lib)", ToolOptions.BUILD_LIBDIRECTORY, 0, 300)
+        
     addCheckBox(othersComposite, "Generate a parse tree listener (-listener)", ToolOptions.BUILD_LISTENER,
       trueFalseValues, 0)
 


### PR DESCRIPTION
Addresses issue #145.
This pull request contains basic functionality to specify where the ANTLR Tool should look for IMPORTed grammars. Note it is entirely up to the user to ensure that the workspace setting will work for all projects that use the ANTLR tool. The individual projects can of course set their own preference.
I also left some debugging statements in the code so it is easier to understand this xtend processing. The debug is off by default.
TODO:
- Add file selection dialog
- Add variable resolution

Please review