### PR TITLE
Issue #71: Override project location

### DIFF
--- a/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/GenerateAntlr4.mwe2
+++ b/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/GenerateAntlr4.mwe2
@@ -143,7 +143,7 @@ Workflow {
       // provides a compare view
       fragment = compare.CompareFragment auto-inject {}
 
-      // provides a compare view
+      // generates New project wizard
       fragment = projectWizard.SimpleProjectWizardFragment auto-inject {
         generatorProjectName = "${projectName}.generator"
         fileExtension = fileExtensions

--- a/antlr4ide.ui/plugin.xml
+++ b/antlr4ide.ui/plugin.xml
@@ -345,8 +345,8 @@
          point="org.eclipse.ui.newWizards">
       <wizard
             category="org.eclipse.ui.Basic"
-            class="com.github.jknack.antlr4ide.ui.Antlr4ExecutableExtensionFactory:com.github.jknack.antlr4ide.ui.wizard.Antlr4NewProjectWizard"
-            id="com.github.jknack.antlr4ide.ui.wizard.Antlr4NewProjectWizard"
+            class="com.github.jknack.antlr4ide.ui.Antlr4ExecutableExtensionFactory:com.github.jknack.antlr4ide.ui.wizard.Antlr4NewProjectWizardX"
+            id="com.github.jknack.antlr4ide.ui.wizard.Antlr4NewProjectWizardX"
             name="ANTLR 4 Project"
             icon="icons/g.png"
             project="true">

--- a/antlr4ide.ui/plugin.xml
+++ b/antlr4ide.ui/plugin.xml
@@ -345,8 +345,8 @@
          point="org.eclipse.ui.newWizards">
       <wizard
             category="org.eclipse.ui.Basic"
-            class="com.github.jknack.antlr4ide.ui.Antlr4ExecutableExtensionFactory:com.github.jknack.antlr4ide.ui.wizard.Antlr4NewProjectWizardX"
-            id="com.github.jknack.antlr4ide.ui.wizard.Antlr4NewProjectWizardX"
+            class="com.github.jknack.antlr4ide.ui.Antlr4ExecutableExtensionFactory:com.github.jknack.antlr4ide.ui.wizard.Antlr4NewProjectWizardV2"
+            id="com.github.jknack.antlr4ide.ui.wizard.Antlr4NewProjectWizardV2"
             name="ANTLR 4 Project"
             icon="icons/g.png"
             project="true">

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/wizard/Antlr4NewProjectWizardV2.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/wizard/Antlr4NewProjectWizardV2.java
@@ -1,3 +1,7 @@
+/**
+ * This class is based on the xtend generated class /antlr4ide/antlr4ide.ui/src/generated/java/com/github/jknack/antlr4ide/ui/wizard/Antlr4NewProjectWizard.java
+ * This version has the addition of storing the project location if the user select override default location.
+ */
 package com.github.jknack.antlr4ide.ui.wizard;
 
 import org.eclipse.ui.dialogs.WizardNewProjectCreationPage;
@@ -6,14 +10,14 @@ import org.eclipse.xtext.ui.wizard.IProjectCreator;
 import com.google.inject.Inject;
 
 
-public class Antlr4NewProjectWizardX extends org.eclipse.xtext.ui.wizard.XtextNewProjectWizard  {
+public class Antlr4NewProjectWizardV2 extends org.eclipse.xtext.ui.wizard.XtextNewProjectWizard  {
 
 	private WizardNewProjectCreationPage mainPage;
 	
 	@Inject
-	public Antlr4NewProjectWizardX(IProjectCreator projectCreator) {
+	public Antlr4NewProjectWizardV2(IProjectCreator projectCreator) {
 		super(projectCreator);
-		setWindowTitle("New Antlr4 Project.2");
+		setWindowTitle("New Antlr4 Project");
 	}
 
 	/**
@@ -23,7 +27,7 @@ public class Antlr4NewProjectWizardX extends org.eclipse.xtext.ui.wizard.XtextNe
 	@Override
 	public void addPages() {
 		mainPage = new WizardNewProjectCreationPage("basicNewProjectPage");
-		mainPage.setTitle("Antlr4 Project.2");
+		mainPage.setTitle("Antlr4 Project");
 		mainPage.setDescription("Create a new Antlr4 project.");
 		addPage(mainPage);
 	}

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/wizard/Antlr4NewProjectWizardX.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/wizard/Antlr4NewProjectWizardX.java
@@ -1,0 +1,45 @@
+package com.github.jknack.antlr4ide.ui.wizard;
+
+import org.eclipse.ui.dialogs.WizardNewProjectCreationPage;
+import org.eclipse.xtext.ui.wizard.IProjectInfo;
+import org.eclipse.xtext.ui.wizard.IProjectCreator;
+import com.google.inject.Inject;
+
+
+public class Antlr4NewProjectWizardX extends org.eclipse.xtext.ui.wizard.XtextNewProjectWizard  {
+
+	private WizardNewProjectCreationPage mainPage;
+	
+	@Inject
+	public Antlr4NewProjectWizardX(IProjectCreator projectCreator) {
+		super(projectCreator);
+		setWindowTitle("New Antlr4 Project.2");
+	}
+
+	/**
+	 * Use this method to add pages to the wizard.
+	 * The one-time generated version of this class will add a default new project page to the wizard.
+	 */
+	@Override
+	public void addPages() {
+		mainPage = new WizardNewProjectCreationPage("basicNewProjectPage");
+		mainPage.setTitle("Antlr4 Project.2");
+		mainPage.setDescription("Create a new Antlr4 project.");
+		addPage(mainPage);
+	}
+
+	
+	/**
+	 * Use this method to read the project settings from the wizard pages and feed them into the project info class.
+	 */
+	@Override
+	protected IProjectInfo getProjectInfo() {
+		com.github.jknack.antlr4ide.ui.wizard.Antlr4ProjectInfo projectInfo = new com.github.jknack.antlr4ide.ui.wizard.Antlr4ProjectInfo();
+		projectInfo.setProjectName(mainPage.getProjectName());
+        if (!mainPage.useDefaults()) {
+            projectInfo.setLocationPath(mainPage.getLocationPath());
+        }
+		return projectInfo;
+	}
+
+}

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/wizard/Antlr4ProjectInfo.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/wizard/Antlr4ProjectInfo.java
@@ -1,5 +1,13 @@
 package com.github.jknack.antlr4ide.ui.wizard;
 
+import org.eclipse.core.runtime.IPath;
+
 public class Antlr4ProjectInfo extends org.eclipse.xtext.ui.wizard.DefaultProjectInfo {
+	private IPath locationPath;
 	
+	public void setLocationPath(IPath locationPath) {
+		this.locationPath = locationPath;
+	}
+	
+	public IPath getLocationPath() { return locationPath; }
 }


### PR DESCRIPTION
This is a nasty hack that basically bypass the code generation framework.
Solves issue #71 

This pull request bypass the generated Antlr4NewProjectWizard class by pointing the plugin.xml extension point to the hand written Antlr4NewProjectWizardV2.java file. The generated file is still there, but is not being used.

Once we figure out how to control the code generation we can revisit this.

The file 
`/antlr4ide/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/GenerateAntlr4.mwe2`
contains the workflow that among many other things generates the new project wizard.

The generated wizard does not contain logic to store the project location information if the user decide to override the default location.

This pull request basically use a hand crafted new wizard code and change the wizard extension in the `plugin.xml` to use the new java code.