### PR TITLE
Build sequence: Lexer, Parser then Combined grammars

### DIFF
--- a/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/Antlr4Generator.xtend
+++ b/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/Antlr4Generator.xtend
@@ -52,7 +52,7 @@ class Antlr4Generator implements IGenerator {
    * @param fsa The Xtext file system access (not used).
    */
   override doGenerate(Resource resource, IFileSystemAccess fsa) {
-  if(DEBUG) System::out.println("Antlr4Generator doGenerate #0. optionsProvider.class >"+optionsProvider.getClass()+"<")
+  if(DEBUG) System::out.println("Antlr4Generator doGenerate #0. resource.class >"+resource.getClass()+"<")
   
     checkNotNull(resource)
     checkNotNull(fsa)

--- a/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/ToolRunner.xtend
+++ b/antlr4ide.core/src/main/java/com/github/jknack/antlr4ide/generator/ToolRunner.xtend
@@ -38,9 +38,9 @@ class ToolRunner {
    * The embedded jar will be used unless options#antlrTool path is set to something else.
    */
   def run(IFile file, ToolOptions options, Console console) {
-    val ex=new Exception()
-    System::out.println("---\n--- ToolRunner run file>"+file+"<")
-    for(StackTraceElement s: ex.stackTrace) System::out.println("    "+s.toString)
+//    val ex=new Exception()
+//    System::out.println("---\n--- ToolRunner run file>"+file+"<")
+//    for(StackTraceElement s: ex.stackTrace) System::out.println("    "+s.toString)
 
 
     val startBuild = System.currentTimeMillis();
@@ -129,7 +129,7 @@ class ToolRunner {
     val distribution = Distributions.get(jar)
     val version = distribution.key
 
-    System::out.println("    ToolRunner validate file>"+jar+"< version>"+version+"<")
+//    System::out.println("    ToolRunner validate file>"+jar+"< version>"+version+"<")
 
     if (version != "") {
       console.info("ANTLR Tool v%s (%s)", version, jar)

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/Antlr4UiModule.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/Antlr4UiModule.java
@@ -144,6 +144,7 @@ public class Antlr4UiModule extends com.github.jknack.antlr4ide.ui.AbstractAntlr
 
   // FIXME: due to "Xtext based editor does not start since 2.5 without JDT installed",
   // https://bugs.eclipse.org/bugs/show_bug.cgi?id=424455
+  // TODO: Check if still needed (HS 20161118)
   public void configureIStorage2UriMapperJdtExtensions(final Binder binder) {
     binder.bind(IStorage2UriMapperJdtExtensions.class).toProvider(
         Providers.of((IStorage2UriMapperJdtExtensions) (new Storage2UriMapperJavaImpl())));
@@ -153,4 +154,13 @@ public class Antlr4UiModule extends com.github.jknack.antlr4ide.ui.AbstractAntlr
   public Class<? extends IProjectCreator> bindIProjectCreator() {
     return JdtFreeProjectCreator.class;
   }
+  
+  
+  // Override needed to control build sequence
+  // contributed by org.eclipse.xtext.generator.generator.GeneratorFragment
+  @Override
+  public Class<? extends org.eclipse.xtext.builder.IXtextBuilderParticipant> bindIXtextBuilderParticipant() {
+	return com.github.jknack.antlr4ide.ui.builder.Antlr4BuilderParticipant.class;
+  }
+  
 }

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/builder/Antlr4BuilderParticipant.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/builder/Antlr4BuilderParticipant.java
@@ -33,6 +33,7 @@ public class Antlr4BuilderParticipant extends org.eclipse.xtext.builder.BuilderP
 	          getRelevantDeltas(org.eclipse.xtext.builder.IXtextBuilderParticipant.IBuildContext context) 
 	{
 		List<org.eclipse.xtext.resource.IResourceDescription.Delta> result = super.getRelevantDeltas(context);
+		if (result.size()<=1) return result; // no need to sort just one entry
 		
 		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultLexers = new ArrayList(); 
 		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultOthers = new ArrayList();

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/builder/Antlr4BuilderParticipant.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/builder/Antlr4BuilderParticipant.java
@@ -14,7 +14,20 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 
 public class Antlr4BuilderParticipant extends org.eclipse.xtext.builder.BuilderParticipant {
+
+	static boolean DEBUG=false;
 	
+	/**
+	 * Build dependency strategy
+	 * ===
+	 * 
+	 * - TODO: If a grammar is used as IMPORT in other grammars, figure out if it should be built 
+	 * - Build sequence
+	 * - - Lexer grammars
+	 * - - Parser grammars
+	 * - - Combined grammars
+	 * 
+	 */
 	@Override
 	protected List<org.eclipse.xtext.resource.IResourceDescription.Delta> 
 	          getRelevantDeltas(org.eclipse.xtext.builder.IXtextBuilderParticipant.IBuildContext context) 
@@ -30,6 +43,7 @@ public class Antlr4BuilderParticipant extends org.eclipse.xtext.builder.BuilderP
 		for (org.eclipse.xtext.resource.IResourceDescription.Delta delta : result) {
 			Resource resource = context.getResourceSet().getResource(delta.getUri(), true);
 			Grammar grammar = grammarFromResource(resource);
+			if(DEBUG)
 			System.out.println(">>> Antlr4BuilderParticipant getRelevantDeltas ["+i+"]>"+delta.getUri()+"< type>"+grammar.getType()+"<");
 				
 			if (grammar.getType()==GrammarType.LEXER)
@@ -47,24 +61,30 @@ public class Antlr4BuilderParticipant extends org.eclipse.xtext.builder.BuilderP
 		resultFinal.addAll(resultLexers);
 		resultFinal.addAll(resultOthers);
 		
-		i=0;
-		for (org.eclipse.xtext.resource.IResourceDescription.Delta delta : resultFinal) {
-			System.out.println("++> Antlr4BuilderParticipant getRelevantDeltas ["+i+"]>"+delta.getUri()+"<");
+		if(DEBUG) {
+		  i=0;
+		  for (org.eclipse.xtext.resource.IResourceDescription.Delta delta : resultFinal) {
+  			System.out.println("++> Antlr4BuilderParticipant getRelevantDeltas ["+i+"]>"+delta.getUri()+"<");
 			i++;
+	  	  }
 		}
-		
 		return resultFinal;
 	}
 	
-	
+
+	/**
+	 * Reads a grammar using a Resource as input.
+	 * This implementation is inspired from @see(com.github.jknack.antlr4ide.ui.services.DefaultGrammarResource) 
+	 */
 	private Grammar grammarFromResource(Resource _resourceFrom) {
-// from com.github.jknack.antlr4ide.ui.services.DefaultGrammarResource;
 	    EList<EObject> _contents = _resourceFrom.getContents();
 	    EObject _head = IterableExtensions.<EObject>head(_contents);
 	    return ((Grammar) _head);
 	}
 	
-	
+	/**
+	 * Compare two resource URIs as strings.
+	 */
 	private class CompareUri implements Comparator<org.eclipse.xtext.resource.IResourceDescription.Delta> {
 	    public int compare(org.eclipse.xtext.resource.IResourceDescription.Delta delta1
 			             , org.eclipse.xtext.resource.IResourceDescription.Delta delta2)
@@ -74,79 +94,4 @@ public class Antlr4BuilderParticipant extends org.eclipse.xtext.builder.BuilderP
 	}
 	
 }
-
-/*
- * Ideas for build dependency strategy
- * ===
- * 
- * - If a grammar is used as IMPORT in other grammars, figure out if it should be built 
- * - Build sequence
- * - - Lexer grammars
- * - - Parser grammars
- * - - Combined grammars
- * 
- * - When rebuilding look for tool options 
- * - - For the grammar itself
- * - - For the project
- * - - For the workspace
- * - - Tool defaults
- * 
- * import org.eclipse.emf.ecore.resource.Resource;
- * Resource resource = context.getResourceSet().getResource(delta.getUri(), true);
- * 
- * import org.eclipse.core.resources.IFile;
- * IFile _fileFrom = ToolRunner.this.grammarResource.fileFrom(resource);
- * 
- * import com.github.jknack.antlr4ide.lang.Grammar;
- * final Grammar grammar = ToolRunner.this.grammarResource.grammarFrom(file);
- * 
- * class org.eclipse.xtext.resource.impl.DefaultResourceDescriptionDelta
- */
-
-
-/* 
- * from antlr4ide.core/com.github.jknack.antlr4ide.generator.ToolRunner.xtend
-    // set -lib when is empty
-    val lib = options.libDirectory
-    if (lib == null || lib.empty) {
-      val grammar = grammarResource.grammarFrom(file)
-      val libs = grammar.imports.map[
-        grammarResource.fileFrom(it.importURI).parent
-      ].toSet
-      if (libs.size > 0) {
-        options.libDirectory = libs.iterator.next.location.toOSString
-      }
-    }
- * which in java is
- * 
-    import com.github.jknack.antlr4ide.lang.Grammar;
-    import com.github.jknack.antlr4ide.lang.Import;
-    import com.github.jknack.antlr4ide.services.GrammarResource;
-    import com.github.jknack.antlr4ide.services.ModelExtensions;
-    
-    final Grammar grammar = this.grammarResource.grammarFrom(file);
-        Set<Import> _imports = ModelExtensions.imports(grammar);
-        final Function1<Import, IContainer> _function = new Function1<Import, IContainer>() {
-          @Override
-          public IContainer apply(final Import it) {
-            Grammar _importURI = it.getImportURI();
-            IFile _fileFrom = ToolRunner.this.grammarResource.fileFrom(_importURI);
-            return _fileFrom.getParent();
-          }
-        };
-        Iterable<IContainer> _map = IterableExtensions.<Import, IContainer>map(_imports, _function);
-        final Set<IContainer> libs = IterableExtensions.<IContainer>toSet(_map);
-        int _size = libs.size();
-        boolean _greaterThan = (_size > 0);
-        if (_greaterThan) {
-          Iterator<IContainer> _iterator = libs.iterator();
-          IContainer _next = _iterator.next();
-          IPath _location_1 = _next.getLocation();
-          String _oSString_1 = _location_1.toOSString();
-          options.setLibDirectory(_oSString_1);
-        }
-      }
- *
- *     See also the Grammar and GrammarType in package com.github.jknack.antlr4ide.lang
- */
 

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/builder/Antlr4BuilderParticipant.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/builder/Antlr4BuilderParticipant.java
@@ -35,8 +35,9 @@ public class Antlr4BuilderParticipant extends org.eclipse.xtext.builder.BuilderP
 		List<org.eclipse.xtext.resource.IResourceDescription.Delta> result = super.getRelevantDeltas(context);
 		if (result.size()<=1) return result; // no need to sort just one entry
 		
-		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultLexers = new ArrayList(); 
-		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultOthers = new ArrayList();
+		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultLexers  = new ArrayList(); 
+		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultParsers = new ArrayList(); 
+		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultOthers  = new ArrayList();
 
 		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultFinal  = new ArrayList();
 		
@@ -50,16 +51,23 @@ public class Antlr4BuilderParticipant extends org.eclipse.xtext.builder.BuilderP
 			if (grammar.getType()==GrammarType.LEXER)
 				resultLexers.add(delta);
 			else
+  		    if (grammar.getType()==GrammarType.PARSER)
+				resultParsers.add(delta);
+			else
 				resultOthers.add(delta);
 				
 			i++;
 		}
 		
 		
-		Collections.sort(resultLexers,new CompareUri());
-		Collections.sort(resultOthers,new CompareUri());
+		Comparator compareUri = new CompareUri() ;
+		
+		Collections.sort(resultLexers, compareUri);
+		Collections.sort(resultParsers, compareUri);
+		Collections.sort(resultOthers, compareUri);
 		
 		resultFinal.addAll(resultLexers);
+		resultFinal.addAll(resultParsers);
 		resultFinal.addAll(resultOthers);
 		
 		if(DEBUG) {

--- a/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/builder/Antlr4BuilderParticipant.java
+++ b/antlr4ide.ui/src/main/java/com/github/jknack/antlr4ide/ui/builder/Antlr4BuilderParticipant.java
@@ -1,0 +1,152 @@
+package com.github.jknack.antlr4ide.ui.builder;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+import org.eclipse.xtext.builder.IXtextBuilderParticipant.IBuildContext;
+import org.eclipse.emf.ecore.resource.Resource;
+import com.github.jknack.antlr4ide.lang.Grammar;
+import com.github.jknack.antlr4ide.lang.GrammarType;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+
+public class Antlr4BuilderParticipant extends org.eclipse.xtext.builder.BuilderParticipant {
+	
+	@Override
+	protected List<org.eclipse.xtext.resource.IResourceDescription.Delta> 
+	          getRelevantDeltas(org.eclipse.xtext.builder.IXtextBuilderParticipant.IBuildContext context) 
+	{
+		List<org.eclipse.xtext.resource.IResourceDescription.Delta> result = super.getRelevantDeltas(context);
+		
+		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultLexers = new ArrayList(); 
+		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultOthers = new ArrayList();
+
+		List<org.eclipse.xtext.resource.IResourceDescription.Delta> resultFinal  = new ArrayList();
+		
+		int i=0;
+		for (org.eclipse.xtext.resource.IResourceDescription.Delta delta : result) {
+			Resource resource = context.getResourceSet().getResource(delta.getUri(), true);
+			Grammar grammar = grammarFromResource(resource);
+			System.out.println(">>> Antlr4BuilderParticipant getRelevantDeltas ["+i+"]>"+delta.getUri()+"< type>"+grammar.getType()+"<");
+				
+			if (grammar.getType()==GrammarType.LEXER)
+				resultLexers.add(delta);
+			else
+				resultOthers.add(delta);
+				
+			i++;
+		}
+		
+		
+		Collections.sort(resultLexers,new CompareUri());
+		Collections.sort(resultOthers,new CompareUri());
+		
+		resultFinal.addAll(resultLexers);
+		resultFinal.addAll(resultOthers);
+		
+		i=0;
+		for (org.eclipse.xtext.resource.IResourceDescription.Delta delta : resultFinal) {
+			System.out.println("++> Antlr4BuilderParticipant getRelevantDeltas ["+i+"]>"+delta.getUri()+"<");
+			i++;
+		}
+		
+		return resultFinal;
+	}
+	
+	
+	private Grammar grammarFromResource(Resource _resourceFrom) {
+// from com.github.jknack.antlr4ide.ui.services.DefaultGrammarResource;
+	    EList<EObject> _contents = _resourceFrom.getContents();
+	    EObject _head = IterableExtensions.<EObject>head(_contents);
+	    return ((Grammar) _head);
+	}
+	
+	
+	private class CompareUri implements Comparator<org.eclipse.xtext.resource.IResourceDescription.Delta> {
+	    public int compare(org.eclipse.xtext.resource.IResourceDescription.Delta delta1
+			             , org.eclipse.xtext.resource.IResourceDescription.Delta delta2)
+	    {
+	    	return delta1.getUri().toString().compareTo(delta2.getUri().toString());
+	    }
+	}
+	
+}
+
+/*
+ * Ideas for build dependency strategy
+ * ===
+ * 
+ * - If a grammar is used as IMPORT in other grammars, figure out if it should be built 
+ * - Build sequence
+ * - - Lexer grammars
+ * - - Parser grammars
+ * - - Combined grammars
+ * 
+ * - When rebuilding look for tool options 
+ * - - For the grammar itself
+ * - - For the project
+ * - - For the workspace
+ * - - Tool defaults
+ * 
+ * import org.eclipse.emf.ecore.resource.Resource;
+ * Resource resource = context.getResourceSet().getResource(delta.getUri(), true);
+ * 
+ * import org.eclipse.core.resources.IFile;
+ * IFile _fileFrom = ToolRunner.this.grammarResource.fileFrom(resource);
+ * 
+ * import com.github.jknack.antlr4ide.lang.Grammar;
+ * final Grammar grammar = ToolRunner.this.grammarResource.grammarFrom(file);
+ * 
+ * class org.eclipse.xtext.resource.impl.DefaultResourceDescriptionDelta
+ */
+
+
+/* 
+ * from antlr4ide.core/com.github.jknack.antlr4ide.generator.ToolRunner.xtend
+    // set -lib when is empty
+    val lib = options.libDirectory
+    if (lib == null || lib.empty) {
+      val grammar = grammarResource.grammarFrom(file)
+      val libs = grammar.imports.map[
+        grammarResource.fileFrom(it.importURI).parent
+      ].toSet
+      if (libs.size > 0) {
+        options.libDirectory = libs.iterator.next.location.toOSString
+      }
+    }
+ * which in java is
+ * 
+    import com.github.jknack.antlr4ide.lang.Grammar;
+    import com.github.jknack.antlr4ide.lang.Import;
+    import com.github.jknack.antlr4ide.services.GrammarResource;
+    import com.github.jknack.antlr4ide.services.ModelExtensions;
+    
+    final Grammar grammar = this.grammarResource.grammarFrom(file);
+        Set<Import> _imports = ModelExtensions.imports(grammar);
+        final Function1<Import, IContainer> _function = new Function1<Import, IContainer>() {
+          @Override
+          public IContainer apply(final Import it) {
+            Grammar _importURI = it.getImportURI();
+            IFile _fileFrom = ToolRunner.this.grammarResource.fileFrom(_importURI);
+            return _fileFrom.getParent();
+          }
+        };
+        Iterable<IContainer> _map = IterableExtensions.<Import, IContainer>map(_imports, _function);
+        final Set<IContainer> libs = IterableExtensions.<IContainer>toSet(_map);
+        int _size = libs.size();
+        boolean _greaterThan = (_size > 0);
+        if (_greaterThan) {
+          Iterator<IContainer> _iterator = libs.iterator();
+          IContainer _next = _iterator.next();
+          IPath _location_1 = _next.getLocation();
+          String _oSString_1 = _location_1.toOSString();
+          options.setLibDirectory(_oSString_1);
+        }
+      }
+ *
+ *     See also the Grammar and GrammarType in package com.github.jknack.antlr4ide.lang
+ */
+


### PR DESCRIPTION
Please review.
Fixes #101 
This fixes the random build sequence of antlr grammars when a project is rebuilt.
Build sequence before fix, note the type default_hack means combined grammar:
```
>>>[0]>platform:/resource/TestStuff/src-import/imports/B.g4< type>lexer<
>>>[1]>platform:/resource/TestStuff/src-import/testissue.g4< type>default_hack_<
>>>[2]>platform:/resource/TestStuff/src-import/imports/A.g4< type>lexer<
>>>[3]>platform:/resource/TestStuff/issue154/testissue154.g4< type>default_hack_<
>>>[4]>platform:/resource/TestStuff/src-import/imports/C.g4< type>lexer<
>>>[5]>platform:/resource/TestStuff/src/testissues.g4< type>default_hack_<
```

After fix the grammars are sorted and lexers come before combined and parser grammars
```
++>[0]>platform:/resource/TestStuff/src-import/imports/A.g4<
++>[1]>platform:/resource/TestStuff/src-import/imports/B.g4<
++>[2]>platform:/resource/TestStuff/src-import/imports/C.g4<
++>[3]>platform:/resource/TestStuff/issue154/testissue154.g4<
++>[4]>platform:/resource/TestStuff/src-import/testissue.g4<
++>[5]>platform:/resource/TestStuff/src/testissues.g4<
```